### PR TITLE
bump oauth2 dependency

### DIFF
--- a/lib/mailup.rb
+++ b/lib/mailup.rb
@@ -168,6 +168,13 @@ module MailUp
         raise BadRequest.new response.parsed
       when 401
         raise Unauthorized.new
+      when 403
+        case response.body
+        when /Too many requests/i
+          raise TooManyRequests.new
+        else
+          raise ClientError.new response.parsed
+        end
       when 404
         raise NotFound.new
       when 400...500

--- a/mailup.gemspec
+++ b/mailup.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'oauth2', '~> 0.9', '>= 0.9.2'
+  gem.add_runtime_dependency 'oauth2', '~> 1.0'
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Thank you for providing this gem. I suspect that many projects, ours included, use oauth2 >= 1.0 which is not compatible with this gemspec. Is there a reason this can't be updated? We're using a forked version with this change successfully at privy.com, although there don't seem to be any tests I can run to confirm the change.
